### PR TITLE
Add gadgetisimo.ro open-source index to Romania section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Lists of open source projects mainly made by developers of a country or region:
 - [Netherlands](https://github.com/IonicaBizau/made-in-netherlands)
 - [Poland](https://github.com/IonicaBizau/made-in-poland)
 - [Portugal](https://github.com/IonicaBizau/made-in-portugal)
-- [Romania](https://github.com/IonicaBizau/made-in-romania) [ [uglify](https://github.com/mishoo/UglifyJS) ]
+- [Romania](https://github.com/IonicaBizau/made-in-romania) [ [uglify](https://github.com/mishoo/UglifyJS) ] [gadgetisimo/ro-open-source](https://github.com/gadgetisimo/ro-open-source)
 - [Russia](https://github.com/igoradamenko/awesome-made-by-russians) [ [firacode ](https://github.com/tonsky/FiraCode) - [kotlin](https://github.com/JetBrains/kotlin) - [opencv](https://github.com/opencv/opencv) - [redux](https://github.com/reduxjs/redux) - [nginx](https://github.com/nginx/nginx) - [emmet](https://github.com/emmetio/emmet) ]
 - [Serbia](https://github.com/IonicaBizau/made-in-serbia)
 - [Slovakia](https://github.com/IonicaBizau/made-in-slovakia)


### PR DESCRIPTION
Added [gadgetisimo/ro-open-source](https://github.com/gadgetisimo/ro-open-source) as an additional curated list for Romanian OSS, alongside made-in-romania.
The list is actively maintained, categorized, and bilingual (RO + EN).